### PR TITLE
RC - new features and bugs fixed

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -36,7 +36,8 @@
             "tr",
             "th",
             "br",
-            "strong"
+            "strong",
+            "pul"
         ]
     }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -37,7 +37,8 @@
             "th",
             "br",
             "strong",
-            "pul"
+            "pul",
+            "printButton"
         ]
     }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -60,6 +60,7 @@
                 "severity": "warning"
             }
         ],
-        "media-feature-range-notation": "prefix"
+        "media-feature-range-notation": "prefix",
+        "color-function-notation": "legacy"
     }
 }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,29 +1,13 @@
-import { CollapsibleConstants, ClickDisablerConstants } from './constants';
-import { ClickDisabler, CollapsibleGroupCommand, CollapsibleBlock } from './shortcodes';
+import { initializeCollapsibles, initializeClickDisabler, printAllArticles } from './modules';
 
 // Listen for the DOMContentLoaded event to ensure the DOM is fully loaded before executing the script.
 document.addEventListener('DOMContentLoaded', function () {
-  // An array to hold all the CollapsibleBlock instances.
-  const collapsibleBlocks = [];
-  // Query the DOM for elements matching the collapsible block selector.
-  document.querySelectorAll(CollapsibleConstants.collapsibleBlockSelector).forEach(collapsibleBlockElement => {
-    collapsibleBlocks.push(new CollapsibleBlock(collapsibleBlockElement));
-  });
+  initializeCollapsibles();
+  initializeClickDisabler();
 
-  // An array to hold all the CollapsibleGroupCommand instances.
-  const collapsibleGroupCommands = [];
-  // Query the DOM for elements matching the collapsible group command selector.
-  document.querySelectorAll(CollapsibleConstants.collapsibleGroupCommandSelector).forEach(collapsibleGroupCommandElement => {
-    // Extract the groupId attribute value to identify which group the command controls.
-    const groupId = collapsibleGroupCommandElement.getAttribute(CollapsibleConstants.groupIdAttribute);
-    // Filter the collapsibleBlocks array to get only those blocks that belong to the current group.
-    const filteredCollapsibleBlocks = collapsibleBlocks.filter(item => item.groupId === groupId);
-    // Create a new CollapsibleGroupCommand instance with the filtered blocks and add it to the array.
-    collapsibleGroupCommands.push(new CollapsibleGroupCommand(collapsibleGroupCommandElement, filteredCollapsibleBlocks));
-  });
-
-  const disabledElements = [];
-  document.querySelectorAll(ClickDisablerConstants.disabledElementSelector).forEach(disabledElement => {
-    disabledElements.push(new ClickDisabler(disabledElement));
-  });
 });
+
+const printButton = document.getElementById('print-button');
+if (printButton) {
+  printButton.addEventListener('click', printAllArticles);
+}

--- a/assets/js/modules/clickDisabler.js
+++ b/assets/js/modules/clickDisabler.js
@@ -1,0 +1,17 @@
+import { ClickDisablerConstants } from '../constants';
+import { ClickDisabler } from '../shortcodes';
+
+const disabledElements = [];
+
+/**
+ * Initializes the click disabler functionality by selecting all elements
+ * that match the disabled element selector and creating a new ClickDisabler
+ * instance for each of them.
+ *
+ * @function
+ */
+export function initializeClickDisabler() {
+  document.querySelectorAll(ClickDisablerConstants.disabledElementSelector).forEach(disabledElement => {
+    disabledElements.push(new ClickDisabler(disabledElement));
+  });
+}

--- a/assets/js/modules/collapsibles.js
+++ b/assets/js/modules/collapsibles.js
@@ -1,0 +1,38 @@
+import { CollapsibleConstants } from '../constants';
+import { CollapsibleGroupCommand, CollapsibleBlock } from '../shortcodes';
+
+const collapsibleBlocks = [];
+const collapsibleGroupCommands = [];
+
+/**
+ * Initializes all the collapsibles.
+ */
+export function initializeCollapsibles() {
+  document.querySelectorAll(CollapsibleConstants.collapsibleBlockSelector).forEach(collapsibleBlockElement => {
+    collapsibleBlocks.push(new CollapsibleBlock(collapsibleBlockElement));
+  });
+
+  document.querySelectorAll(CollapsibleConstants.collapsibleGroupCommandSelector).forEach(collapsibleGroupCommandElement => {
+    const groupId = collapsibleGroupCommandElement.getAttribute(CollapsibleConstants.groupIdAttribute);
+    const filteredCollapsibleBlocks = collapsibleBlocks.filter(item => item.groupId === groupId);
+    collapsibleGroupCommands.push(new CollapsibleGroupCommand(collapsibleGroupCommandElement, filteredCollapsibleBlocks));
+  });
+}
+
+/**
+ * Opens all collapsible blocks.
+ */
+export function openAllBlocks() {
+  collapsibleGroupCommands.forEach(groupCommand => {
+    groupCommand.expandAll();
+  });
+}
+
+/**
+ * Closes all collapsible blocks.
+ */
+export function closeAllBlocks() {
+  collapsibleGroupCommands.forEach(groupCommand => {
+    groupCommand.collapseAll();
+  });
+}

--- a/assets/js/modules/index.js
+++ b/assets/js/modules/index.js
@@ -1,0 +1,3 @@
+export { initializeCollapsibles, openAllBlocks, closeAllBlocks } from './collapsibles';
+export { initializeClickDisabler } from './clickDisabler';
+export { printAllArticles } from './print';

--- a/assets/js/modules/print.js
+++ b/assets/js/modules/print.js
@@ -1,0 +1,13 @@
+import { openAllBlocks, closeAllBlocks } from './collapsibles';
+
+/**
+ * Opens all blocks, prints the page, and restores the initial state.
+ */
+export function printAllArticles() {
+  openAllBlocks();
+
+  setTimeout(() => {
+    window.print();
+    closeAllBlocks();
+  }, 500);
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -654,3 +654,8 @@ img.img_full {
 .grey-color {
   color: grey;
 }
+
+.article-number-compact {
+  min-width: 0 !important;
+  margin-right: 1rem !important;
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,5 +1,6 @@
 @import "utilities/index";
 @import "abstracts/index";
+@import "components/index";
 @import "shortcodes/index";
 
 html {

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -1,0 +1,32 @@
+.btn-primary {
+    color: #ffffff;
+    background-color: #596978;
+    border: 1px solid transparent;
+    display: inline-block;
+    font-weight: 400;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border-radius: 0.25rem;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  }
+  
+  .btn-primary:hover {
+    color: #ffffff;
+    background-color: #46596b;
+  }
+  
+  .btn-primary:focus, .btn-primary.focus {
+    outline: none;
+  }
+  
+  .btn-primary:disabled, .btn-primary.disabled {
+    color: #ffffff;
+    background-color: #007bff;
+    border-color: #007bff;
+    opacity: 0.65;
+  }

--- a/assets/scss/components/_index.scss
+++ b/assets/scss/components/_index.scss
@@ -1,0 +1,1 @@
+@import "buttons";

--- a/assets/scss/shortcodes/_article.scss
+++ b/assets/scss/shortcodes/_article.scss
@@ -12,6 +12,13 @@
     align-items: baseline;
     font-size: 1em;
 
+    .article-header-group{
+        display: inline-flex;
+        align-items: baseline;
+        white-space: nowrap;
+        position: relative;
+    }
+
     .article-number {
         margin-right: 40px;
         min-width: 60px;
@@ -59,27 +66,26 @@
     }
 }
 
-.article-header .crossed-out-text {
-    position: relative;
+.article-header .crossed-out-text .article-header-group {
+    color: red; /* Color of the crossed out text */
 }
-  
-.article-header .crossed-out-text::after {
+
+.article-header .crossed-out-text .article-header-group::after {
     content: '';
     position: absolute;
     top: 50%; /* Center the crossed out line */
-    left: 0;
-    right: 0;
     height: 1px; /* Height of the line */
     background-color: red; /* Color of the crossed out text */
     transform: translateY(-50%); /* Center verticaly */
     width: 100%; /* Take all the width of the container */
     z-index: -1; /* Put the line behind the other elements */
 }
-  
-.article-header .crossed-out-text .article-number,
-.article-header .crossed-out-text .article-date,
+
+/* Specific class for title to allow this part to be crossed out on multiple lines */
 .article-header .crossed-out-text .article-title {
-    display: inline-block;
-    color: red; /* Color of the crossed out text */
-    position: relative;
+    color: red;
+    text-decoration: line-through;
+    text-decoration-thickness: 1px;
+    text-decoration-color: red;
+    text-decoration-skip-ink: none;
 }

--- a/assets/scss/shortcodes/_index.scss
+++ b/assets/scss/shortcodes/_index.scss
@@ -4,3 +4,4 @@
 @import "list-item";
 @import "faq-block";
 @import "article";
+@import "pul";

--- a/assets/scss/shortcodes/_pul.scss
+++ b/assets/scss/shortcodes/_pul.scss
@@ -1,0 +1,7 @@
+.pul p:has(+ ul) {
+    margin-bottom: 0;
+}
+
+.pul p:has(+ div  ul) {
+    margin-bottom: 0;
+}

--- a/assets/scss/utilities/_index.scss
+++ b/assets/scss/utilities/_index.scss
@@ -1,2 +1,3 @@
 @import "states";
 @import "paddings";
+@import "print";

--- a/assets/scss/utilities/_print.scss
+++ b/assets/scss/utilities/_print.scss
@@ -1,0 +1,22 @@
+@media print {
+    /* Remove unnecessary elements */
+    nav, footer, .footer-item, .sidebar, #print-button, .collapsible-group-command, .collapsible-block__icon {
+        display: none !important;
+    }
+
+    /* Force all content to be visible */
+    * {
+        overflow: visible !important;
+        height: auto !important;
+    }
+
+    /* Remove scrollbars */
+    body {
+        overflow: visible !important;
+    }
+
+    /* Avoid breaks within articles */
+    .article {
+        page-break-inside: avoid;
+    }
+}

--- a/content/de/Rundschreiben/Rundschreiben_2025_01/Allgemeines/_index.md
+++ b/content/de/Rundschreiben/Rundschreiben_2025_01/Allgemeines/_index.md
@@ -8,6 +8,8 @@ keywords: []
 ---
 {{<markdown>}}
 **1.1. Gültige Kodierungsinstrumente**
+
+{{<pul>}}
   
 Ab 1. Juli 2024 gelten folgende Kodierungsinstrumente:
 
@@ -20,8 +22,10 @@ Ab 1. Juli 2024 gelten folgende Kodierungsinstrumente:
 Gesundheitsprobleme - 10. Revision – German Modification
 - ICD-10-GM 2022 Systematisches Verzeichnis, deutsche Version: Zusatzinformationen für den schweizerischen Kontext
 {{</indent>}}
-Die Instrumente zur medizinischen Kodierung finden Sie unter www.statistik.ch → Grundlagen und Erhebungen → Medizinische 
-Kodierung und Klassifikationen → Instrumente zur medizinischen Kodierung → Gültige Instrumente zur medizinischen Kodierung je 
+{{</pul>}}
+
+Die Instrumente zur medizinischen Kodierung finden Sie unter <www.statistik.ch> → Grundlagen und Erhebungen → Medizinische
+Kodierung und Klassifikationen → Instrumente zur medizinischen Kodierung → Gültige Instrumente zur medizinischen Kodierung je
 Jahr.  
   
 Die Dateien der ICD-10-GM in deutscher Sprache werden vom Bundesinstitut für Arzneimittel und Medizinprodukte (BfArM) erstellt 

--- a/content/de/Rundschreiben/Rundschreiben_2025_01/Anhang/_index.md
+++ b/content/de/Rundschreiben/Rundschreiben_2025_01/Anhang/_index.md
@@ -7,6 +7,8 @@ type: docs
 keywords: []
 ---
 
+{{<printButton>}}
+
 Das aktuelle Rundschreiben enthält alle, ab 1. Juli 2024 gültigen «Informationen und Präzisierungen».  
 Legende: <font color="green">Neuerungen in grün</font>, <font color="red">~~Löschungen in rot~~</font>
   
@@ -37,7 +39,7 @@ Z. B.:
 {{<collapsibleGroupCommand groupId="RS2024_2">}}
 
 <a id="0756"></a>
-{{<article number="0756" date="01.07.2024" title="«Exklusivum – Kode weglassen» bei Komplexbehandlungen" collapsibleClass="d-inline-block" groupId="RS2024_2">}}
+{{<article number="0756" date="01.07.2024" title="«Exklusivum – Kode weglassen» bei Komplexbehandlungen" collapsibleClass="d-inline-block" groupId="RS2024_2" numberColor="black">}}
 {{<markdown>}}
 In der Einleitung der CHOP im Abschnitt «Technische Bemerkungen zur CHOP» - «Zusatzinformationen» steht
 […]  
@@ -66,7 +68,7 @@ Folgende Präzisierungen betreffen die Elementgruppe 93.8A.2- «Palliativmedizin
 
 {{<grid class="ps-0">}}
     {{<grid/column>}}
-93.8A.2-: 
+93.8A.2-:
     {{</grid/column>}}
     {{<grid/column>}}
         {{<markdown>}}
@@ -76,10 +78,9 @@ Durchführung eines standardisierten palliativmedizinischen Basisassessments (PB
     {{</grid/column>}}
 {{</grid>}}
 
-
 {{<grid class="ps-0">}}
     {{<grid/column>}}
-93.8B.- : 
+93.8B.- :
     {{</grid/column>}}
     {{<grid/column>}}
         {{<markdown>}}
@@ -266,7 +267,6 @@ Werden hingegen ein craniales MRI, eine neurophysiologische Diagnostik sowie ein
 {{</markdown>}}
 {{</article>}}
 
-
 <a id="0762"></a>
 {{<article number="0762" date="01.01.2024" title="Berücksichtigte Therapiedauer"  collapsibleClass="d-inline-block" groupId="RS2024_2" >}}
 {{<markdown>}}
@@ -447,7 +447,7 @@ Je Eingriff ist der Kode mit der entsprechenden Anzahl von eingesetzten Stents/P
   
 Beispiel: Am Tag X werden zwei selbstexpandierende Prothesen in den Ösophagus eingesetzt. Am Tag Y wird eine selbstexpandie-rende Prothese ausgewechselt.
   
-Kodierung 
+Kodierung
 {{</markdown>}}
 {{<grid class="ps-0">}}
     {{<grid/column>}}
@@ -455,7 +455,7 @@ Tag X:
     {{</grid/column>}}
     {{<grid/column>}}
         {{<markdown>}}
-42.81.41 «Einsetzen und Wechsel von zwei selbstexpandierenden Prothesen (permanenter Tubus) in den Ösophagus, endoskopisch»          
+42.81.41 «Einsetzen und Wechsel von zwei selbstexpandierenden Prothesen (permanenter Tubus) in den Ösophagus, endoskopisch»
         {{</markdown>}}
     {{</grid/column>}}
 {{</grid>}}
@@ -500,8 +500,7 @@ Tag Z:
     {{</grid/column>}}
 {{</grid>}}
 {{<markdown>}}
-   
-   
+
 Je Eingriff ist der Kode so oft zu kodieren, wie Stents/Prothesen implantiert wurden.
   
 Beispiel: Am Tag X werden zwei nicht selbstexpandierende Prothesen am Darm eingelegt. Am Tag Y werden beide entfernt und durch eine selbstexpandierende Prothese ersetzt.

--- a/content/de/Rundschreiben/Rundschreiben_2025_01/Zusatzinformationen_chop/_index.md
+++ b/content/de/Rundschreiben/Rundschreiben_2025_01/Zusatzinformationen_chop/_index.md
@@ -6,6 +6,8 @@ weight: 440
 type: docs
 keywords: []
 ---
+{{<printButton>}}
+
 {{<markdown>}}Legende: <font color="green">Neuerungen in grün</font>, <font color="red">~~Löschungen in rot~~</font>
   
 Die Zusatzinformationen zur CHOP 2024, aus dem Rundschreiben 2024 Nr. 1, sind weiterhin gültig.
@@ -21,20 +23,20 @@ Zusätzliche neue Korrekturen sind hier aufgeführt:
 
 Betrifft alle Sprachversionen
   
-Der Titel vom Kode 00.99.11 ist mit «arthroskopisch» zu ergänzen. Das Beachte unter dem Kode 00.99.11 ist leicht anzupassen. 
+Der Titel vom Kode 00.99.11 ist mit «arthroskopisch» zu ergänzen. Das Beachte unter dem Kode 00.99.11 ist leicht anzupassen.
 Der Zugang des neuen Eingriffs wird aus dem Titel des Kodes 00.99.12 gestrichen.  
-Falls ein Gebiet mittels einem anderen endoskopischen Zugang oder einem anderen Zugangsweg als die genannten vorbehandelt 
-wurde ist weder der 00.99.11 noch der 00.99.12 zu verwenden. Die Bildung einer entsprechenden Resteklasse vom Typ «sonstige» 
+Falls ein Gebiet mittels einem anderen endoskopischen Zugang oder einem anderen Zugangsweg als die genannten vorbehandelt
+wurde ist weder der 00.99.11 noch der 00.99.12 zu verwenden. Die Bildung einer entsprechenden Resteklasse vom Typ «sonstige»
 ist für eine spätere CHOP-Version geplant.
   
-00.99.11 Reoperation in einem bereits offen chirurgisch, thorakoskopisch, <font color="red">~~und~~</font> aparoskopisch <font color="green">und arthroskopisch</font> voroperierten 
+00.99.11 Reoperation in einem bereits offen chirurgisch, thorakoskopisch, <font color="red">~~und~~</font> aparoskopisch <font color="green">und arthroskopisch</font> voroperierten
 {{</markdown>}}
 
 {{<indent level="7">}}
 
 {{<markdown>}}
 Gebiet  
-Beachte: Zusatzkode für die <font color="red">~~Wiedereröffnung eines Operationsgebietes~~</font> <font color="green">Reoperation </font>zur Behandlung einer Komplikation, 
+Beachte: Zusatzkode für die <font color="red">~~Wiedereröffnung eines Operationsgebietes~~</font> <font color="green">Reoperation </font>zur Behandlung einer Komplikation,
 zur Durchführung einer Rezidivoperation oder zur Durchführung einer anderen Operation in diesem Operationsgebiet, sofern in den organspezifischen Kapiteln kein spezifischer Kode vorhanden ist.
 {{</markdown>}}
 {{</indent>}}
@@ -53,7 +55,7 @@ zur Durchführung einer Rezidivoperation oder zur Durchführung einer anderen Op
 
 Betrifft alle Sprachversionen
   
-Als Pendant zum Exklusivum «Drainage durch Aspiration (55.92)» unter 55.0- «Nephrotomie und Nephrostomie» ist die ergänzende 
+Als Pendant zum Exklusivum «Drainage durch Aspiration (55.92)» unter 55.0- «Nephrotomie und Nephrostomie» ist die ergänzende
 Beschreibung «Drainage durch Aspiration an der Niere» unter 55.92 aufzunehmen. Die «perkutan-transrenalen» Eingriffe sind den noch nicht mit dem Kode 55.92 abzubilden. Um dies zu präzisieren sind die zwei unten aufgeführten Exklusiva aufzunehmen.
   
 55.92 Perkutane Aspiration an der Niere (Nierenbecken
@@ -72,7 +74,6 @@ Nierenpunktion
 
 {{</article>}}
 
-
 <a id="3.3"></a>
 {{<article number="3.3" title=" 70.A2.22 «Deszensuschirurgie [Suspensionsoperation], zwei oder drei Kompartimente, laparoskopisch, mit Netz»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
@@ -84,7 +85,6 @@ Betrifft nur die italienische Sprachversion
 
 {{</article>}}
 
-
 <a id="3.4"></a>
 {{<article number="3.4" title="81.A1.13 Langschaftprothese" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
@@ -92,15 +92,14 @@ Betrifft nur die italienische Sprachversion
 
 Betrifft alle Sprachversionen
   
-Bei den Kodes zur Erstimplantation oder Implantation bei Wechsel einer Sonderprothese des Hüftgelenks (81.51.12, 81.51.22) sind 
-die «Beachte» wie folgt anzupassen. Eine achsengeführte Knie-Totalendoprothese ist implizit eine Langschaftprothese. Bei den 
-Kodes 81.54.23 «Erstimplantation einer achsengeführten Totalendoprothese des Kniegelenks» und 81.54.33 «Implantation einer 
+Bei den Kodes zur Erstimplantation oder Implantation bei Wechsel einer Sonderprothese des Hüftgelenks (81.51.12, 81.51.22) sind
+die «Beachte» wie folgt anzupassen. Eine achsengeführte Knie-Totalendoprothese ist implizit eine Langschaftprothese. Bei den
+Kodes 81.54.23 «Erstimplantation einer achsengeführten Totalendoprothese des Kniegelenks» und 81.54.33 «Implantation einer
 achsengeführten Totalendoprothese des Kniegelenks bei einem Prothesenwechsel» ist der Zusatzkode 81.A1.13 «Langschaftprothese» somit nicht zu erfassen.
 
 {{</markdown>}}
 
 {{</article>}}
-
 
 <a id="3.5"></a>
 {{<article number="3.5" title="85.2C.2-, 85.2C.3- Débridement an der Mamma»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
@@ -119,7 +118,7 @@ Betrifft nur die französische Version
 {{<markdown>}}
 
 Betrifft alle Sprachversionen
-Bei den Zusatzinformationen der Elementegruppe 93.8A.2-, der Subkategorie 93.8B.- und der Elementegruppe 93.8B.2- sind folgende «Exklusiva – Kode weglassen» aufzunehmen. In der französischen Sprachversion ist zusätzlich der Titel des Kodes 93.8B.27 
+Bei den Zusatzinformationen der Elementegruppe 93.8A.2-, der Subkategorie 93.8B.- und der Elementegruppe 93.8B.2- sind folgende «Exklusiva – Kode weglassen» aufzunehmen. In der französischen Sprachversion ist zusätzlich der Titel des Kodes 93.8B.27
 zu korrigieren.
 Zum Verständnis des Exklusivum – Kode weglassen bei Komplexbehandlungen s. Präzisierung 0756 im Anhang dieses Rundschreibens. Zudem wurde die Präzisierung 0757 «Informationen und Präzisierungen zur Palliative Care» ergänzt
   
@@ -127,18 +126,15 @@ Zum Verständnis des Exklusivum – Kode weglassen bei Komplexbehandlungen s. Pr
 
 {{</article>}}
 
-
-
 <a id="3.7"></a>
 {{<article number="3.7" title="93.59.5- und 99.84.- Anpassung der «Beachte»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
 Betrifft alle Sprachversionen
-Zur klaren Abgrenzung der Elementegruppe 93.59.5- und der Subkategorie 99.84.- sind die «Beachte» wie folgt anzupassen. Zur 
+Zur klaren Abgrenzung der Elementegruppe 93.59.5- und der Subkategorie 99.84.- sind die «Beachte» wie folgt anzupassen. Zur
 Verdeutlichung wurde ebenfalls die Präzisierung 0758 im Anhang dieses Rundschreibens aufgenommen.
 
-  
 {{</markdown>}}
 
 {{</article>}}

--- a/content/de/Rundschreiben/Rundschreiben_2025_01/Zusatzinformationen_chop/_index.md
+++ b/content/de/Rundschreiben/Rundschreiben_2025_01/Zusatzinformationen_chop/_index.md
@@ -15,7 +15,7 @@ Zusätzliche neue Korrekturen sind hier aufgeführt:
 {{<collapsibleGroupCommand groupId="RS2024CHOP_2">}}
 
 <a id="3.1"></a>
-{{<article number="3.1" title="00.99.11 und 00.99.12 Reoperationen" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.1" title="00.99.11 und 00.99.12 Reoperationen" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -47,7 +47,7 @@ zur Durchführung einer Rezidivoperation oder zur Durchführung einer anderen Op
 {{</article>}}
 
 <a id="3.2"></a>
-{{<article number="3.2" title="55.92 Perkutane Aspiration an der Niere – ergänzende Beschreibung und Exklusiva" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.2" title="55.92 Perkutane Aspiration an der Niere – ergänzende Beschreibung und Exklusiva" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -74,7 +74,7 @@ Nierenpunktion
 
 
 <a id="3.3"></a>
-{{<article number="3.3" title=" 70.A2.22 «Deszensuschirurgie [Suspensionsoperation], zwei oder drei Kompartimente, laparoskopisch, mit Netz»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.3" title=" 70.A2.22 «Deszensuschirurgie [Suspensionsoperation], zwei oder drei Kompartimente, laparoskopisch, mit Netz»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -86,7 +86,7 @@ Betrifft nur die italienische Sprachversion
 
 
 <a id="3.4"></a>
-{{<article number="3.4" title="81.A1.13 Langschaftprothese" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.4" title="81.A1.13 Langschaftprothese" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -103,7 +103,7 @@ achsengeführten Totalendoprothese des Kniegelenks bei einem Prothesenwechsel» 
 
 
 <a id="3.5"></a>
-{{<article number="3.5" title="85.2C.2-, 85.2C.3- Débridement an der Mamma»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.5" title="85.2C.2-, 85.2C.3- Débridement an der Mamma»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -114,7 +114,7 @@ Betrifft nur die französische Version
 {{</article>}}
 
 <a id="3.6"></a>
-{{<article number="3.6" title="93.8A.2- und 93.8B.- Palliativmedizin – Aufnahme von «Exklusiva – Kode weglassen»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.6" title="93.8A.2- und 93.8B.- Palliativmedizin – Aufnahme von «Exklusiva – Kode weglassen»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 
@@ -130,7 +130,7 @@ Zum Verständnis des Exklusivum – Kode weglassen bei Komplexbehandlungen s. Pr
 
 
 <a id="3.7"></a>
-{{<article number="3.7" title="93.59.5- und 99.84.- Anpassung der «Beachte»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2">}}
+{{<article number="3.7" title="93.59.5- und 99.84.- Anpassung der «Beachte»" collapsibleClass="d-inline-block" groupId="RS2024CHOP_2" numberClass="article-number-compact">}}
 
 {{<markdown>}}
 

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -20,5 +20,7 @@ other = "Alle reduzieren"
 other = "Klicken Sie hier, um zu erweitern/reduzieren"
 [collapsible_group_command_click_to_expand_collapse_all_tooltip_text]
 other = "Klicken Sie hier, um alle zu erweitern/reduzieren"
+[print_button_text]
+other = "Drucken"
 [project_title]
 other = "Handbuch Rundschreiben Kodierer"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -21,5 +21,7 @@ other = "Tout fermer"
 other = "Cliquez ici pour développer/réduire"
 [collapsible_group_command_click_to_expand_collapse_all_tooltip_text]
 other = "Cliquez ici pour tout développer/réduire"
+[print_button_text]
+other = "Imprimer"
 [project_title]
 other = "Manuel Rundschreiben Kodierer"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -21,5 +21,7 @@ other = "Comprimere tutto"
 other = "Clicca qui per espandere/comprimere"
 [collapsible_group_command_click_to_expand_collapse_all_tooltip_text]
 other = "Clicca qui per espandere/comprimere tutto"
+[print_button_text]
+other = "Stampare"
 [project_title]
 other = "Rundschreiben Kodierer manuali"

--- a/layouts/shortcodes/article.html
+++ b/layouts/shortcodes/article.html
@@ -8,6 +8,7 @@
 {{ $title := .Get "title" }}
 {{ $groupId := .Get "groupId" | default "" }}
 {{ $buttonClass := "" }}
+{{ $numberClass := .Get "numberClass" | default "" }}
 {{ if eq $removed "true" }}
   {{ $buttonClass = "crossed-out-text" }}
   {{ $numberColor = "red" }}
@@ -28,7 +29,9 @@
       class="d-flex justify-content-start collapsible-block__button {{ $buttonClass }}"
     >
       <span class="article-header-group">
-        <span class="article-number" style="color: {{ $numberColor }};"
+        <span
+          class="article-number {{ $numberClass }}"
+          style="color: {{ $numberColor }};"
           >{{ $number }}
         </span>
         {{ with $date }}

--- a/layouts/shortcodes/article.html
+++ b/layouts/shortcodes/article.html
@@ -27,12 +27,14 @@
       type="button"
       class="d-flex justify-content-start collapsible-block__button {{ $buttonClass }}"
     >
-      <span class="article-number" style="color: {{ $numberColor }};"
-        >{{ $number }}
+      <span class="article-header-group">
+        <span class="article-number" style="color: {{ $numberColor }};"
+          >{{ $number }}
+        </span>
+        {{ with $date }}
+          <span class="article-date">{{ . }}</span>
+        {{ end }}
       </span>
-      {{ with $date }}
-        <span class="article-date">{{ . }}</span>
-      {{ end }}
       <span class="article-title">{{ $title }}</span>
     </button>
   </span>

--- a/layouts/shortcodes/printButton.html
+++ b/layouts/shortcodes/printButton.html
@@ -1,0 +1,5 @@
+{{ $buttonText := .Get "text" | default (T "print_button_text") }}
+<button id="print-button" class="btn-primary" onclick="printAllArticles()">
+  <i class="fa fa-print"></i>
+  {{ $buttonText }}
+</button>

--- a/layouts/shortcodes/pul.html
+++ b/layouts/shortcodes/pul.html
@@ -1,0 +1,4 @@
+{{ $class := .Get "class" | default "" }}
+<div class="pul {{ $class }}">
+  {{ .Inner }}
+</div>


### PR DESCRIPTION
1. space before a list of items to delete (example: 2025.1 Anhang 0761) 
    - => new shortcode `pul` added
2. crossing out is not correct when there is more than one line 
    - => fixed
3. article number must be set to black
    -  => it is already possible: numberColor="black" on the article
4. print all articles
    - => new button, css, and javascript logic
5. spaces in the title of a page
    - => nothing to do. it works very well. See SpiGes
6. make the space after the article number configurable
    - => new css class `.article-number-compact` and new parameter in article shortcode `numberClass` added